### PR TITLE
Fix panic canonical.go

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -117,12 +117,8 @@ func (c *relaxedBodyCanonicalizer) Write(b []byte) (int, error) {
 			if len(c.crlfBuf) > 0 {
 				canonical = append(canonical, c.crlfBuf...)
 				c.crlfBuf = nil
-
-				if len(c.wspBuf) > 0 {
-					canonical = append(canonical, c.wspBuf...)
-					c.wspBuf = nil
-				}
-			} else if len(c.wspBuf) > 0 {
+			}
+			if len(c.wspBuf) > 0 {
 				canonical = append(canonical, ' ')
 				c.wspBuf = nil
 			}
@@ -135,7 +131,10 @@ func (c *relaxedBodyCanonicalizer) Write(b []byte) (int, error) {
 		c.written = true
 	}
 
-	return c.w.Write(canonical)
+	if _, err := c.w.Write(canonical); err != nil {
+		return len(b), err
+	}
+	return len(b), nil
 }
 
 func (c *relaxedBodyCanonicalizer) Close() error {


### PR DESCRIPTION
Panic code

```go
package main

import (
	"log"
	"os"

	dkim "github.com/emersion/go-dkim"
)

func main() {
	r, _ := os.Open(`mail2.eml`)
	verifications, err := dkim.Verify(r)
	if err != nil {
		log.Fatal(err)
	}
	for _, v := range verifications {
		if v.Err == nil {
			log.Println("Valid signature for:", v.Domain)
		} else {
			log.Println("Invalid signature for:", v.Domain, v.Err)
		}
	}
}
```

```
c:\Users\Acer\go\src\test01>test01.exe
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
bufio.(*Reader).fill(0xc04208a000)
        C:/Go/src/bufio/bufio.go:86 +0x226
bufio.(*Reader).WriteTo(0xc04208a000, 0x974098, 0xc042074190, 0x9740c0, 0xc04208a000, 0x3e7010b0001)
        C:/Go/src/bufio/bufio.go:491 +0x114
io.copyBuffer(0x974098, 0xc042074190, 0x5fe500, 0xc04208a000, 0x0, 0x0, 0x0, 0x53d040, 0xc042074100, 0x974098)
        C:/Go/src/io/io.go:382 +0x311
io.Copy(0x974098, 0xc042074190, 0x5fe500, 0xc04208a000, 0xc042074190, 0x0, 0x0)
        C:/Go/src/io/io.go:362 +0x6f
github.com/emersion/go-dkim.verify(0xc0420aa000, 0x1d, 0x20, 0x5fe500, 0xc04208a000, 0xc0420a2000, 0x19c, 0xc0420a2010, 0x18a, 0x488b98, ...)
        C:/Users/Acer/go/src/github.com/emersion/go-dkim/verify.go:293 +0xd57
github.com/emersion/go-dkim.Verify(0x5fe6c0, 0xc042066018, 0xc042066018, 0x0, 0x0, 0x5fd800, 0xc042063f08)
        C:/Users/Acer/go/src/github.com/emersion/go-dkim/verify.go:117 +0x46c
main.main()
        C:/Users/Acer/go/src/test01/main.go:12 +0x69
```