### PR TITLE
Fix canonicalization and add support for folding of DKIM-Signature header

### DIFF
--- a/header.go
+++ b/header.go
@@ -74,10 +74,18 @@ func parseHeaderParams(s string) (map[string]string, error) {
 
 func formatHeaderParams(params map[string]string) string {
 	keys := make([]string, 0, len(params))
+	found := false
 	for k := range params {
-		keys = append(keys, k)
+		if k == "b" {
+			found = true
+		} else {
+			keys = append(keys, k)
+		}
 	}
 	sort.Strings(keys)
+	if found {
+		keys = append(keys, "b")
+	}
 
 	var s string
 	first := true

--- a/sign.go
+++ b/sign.go
@@ -190,7 +190,9 @@ func Sign(w io.Writer, r io.Reader, options *SignOptions) error {
 	}
 
 	params["b"] = ""
-	sigField := strings.TrimRight(formatSignature(params), crlf)
+	sigField := formatSignature(params)
+	sigField = canonicalizers[headerCan].CanonicalizeHeader(sigField)
+	sigField = strings.TrimRight(sigField, crlf)
 	if _, err := hasher.Write([]byte(sigField)); err != nil {
 		return err
 	}

--- a/sign.go
+++ b/sign.go
@@ -217,8 +217,20 @@ func Sign(w io.Writer, r io.Reader, options *SignOptions) error {
 }
 
 func formatSignature(params map[string]string) string {
-	// TODO: fold lines
-	return "DKIM-Signature: " + formatHeaderParams(params) + crlf
+	var fold strings.Builder
+	sig := "DKIM-Signature: " + formatHeaderParams(params) + crlf
+	buf := bytes.NewBufferString(sig)
+	line := make([]byte, 75) // 78 - len("\r\n\s")
+	first := true
+	for len, err := buf.Read(line); err != io.EOF; len, err = buf.Read(line) {
+		if first {
+			first = false
+		} else {
+			fold.WriteString("\r\n ")
+		}
+		fold.Write(line[:len])
+	}
+	return fold.String()
 }
 
 func formatTagList(l []string) string {

--- a/sign_test.go
+++ b/sign_test.go
@@ -22,10 +22,11 @@ const mailBodyString = "Hi.\r\n" +
 
 const mailString = mailHeaderString + "\r\n" + mailBodyString
 
-const signedMailString = "DKIM-Signature: a=rsa-sha256; " +
-	"b=J6O5/fEAf02/V9/gYJG74ZWo+gLcfJcK9fITR52VHdJ9QhkskrJ8IKeuFx9TvfczXx2FBCPYEC3wfud/4FDqO4kXTs5RpFcsiHCEe2XFdqp+ZJk6ww7+b4sLR8Rpj9T2MdcP4u3z2OHJuyr71uKL97HGdwz7+LebEyEvNaoDO0c=; " +
-	"bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv8=; " +
-	"c=simple/simple; d=example.org; h=From:To:Subject:Date:Message-ID; s=brisbane; t=424242; v=1;\r\n" +
+const signedMailString = "DKIM-Signature: a=rsa-sha256; bh=2jUSOH9NhtVGCQWNr9BrIAPreKQjO6Sn7XIkfJVOzv" + "\r\n" +
+	" " + "8=; c=simple/simple; d=example.org; h=From:To:Subject:Date:Message-ID; s=br" + "\r\n" +
+	" " + "isbane; t=424242; v=1; b=bXtqB8uOEvtd1Xv/DHatdjb9onP0+vnzdYBbPMZm1qrRmhSuFH" + "\r\n" +
+	" " + "WsbkETafswNvJ4VqNX0gMoaYvzcmoMkUhW9m4pgZqR5y+62yA+B7WJCd6mz82UVkS1qEJeGjMxX" + "\r\n" +
+	" " + "mmPDkmLDA5HHL5LLTc3DLrxkwWMLzwrhQL48WhNFD1d6L4=;" + "\r\n" +
 	mailHeaderString +
 	"\r\n" +
 	mailBodyString


### PR DESCRIPTION
1. Fix DKIM signature to be canonicalized before hashing

   According to RFC 4871 section 3.7 list item 2.:
   > The DKIM-Signature header field that exists (verifying) or will
   > be inserted (signing) in the message, with the value of the "b="
   > tag deleted (i.e., treated as the empty string), canonicalized
   > using the header canonicalization algorithm specified in the "c="
   > tag, and without a trailing CRLF.

2. Add folding of DKIM-Signature field after 75 characters

3. Fix order of DKIM-Signature fields to move b to the end

   This is required in order to not break the signatures whitespace
   with and without a value for b due to the added support for folding.

All changes have been successfully tested against [dkimvalidator.com](http://dkimvalidator.com) and the Thunderbird extension [DKIM Verifier](https://addons.thunderbird.net/en-US/thunderbird/addon/dkim-verifier/).