### PR TITLE
Implemented case-insensitive header pick.

### DIFF
--- a/header.go
+++ b/header.go
@@ -116,11 +116,13 @@ func newHeaderPicker(h header) *headerPicker {
 }
 
 func (p *headerPicker) Pick(key string) string {
+	key = strings.ToLower(key)
 	at := p.picked[key]
 	for i := len(p.h) - 1; i >= 0; i-- {
 		kv := p.h[i]
 		k, _ := parseHeaderField(kv)
-		if k != key {
+
+		if strings.ToLower(k) != key {
 			continue
 		}
 

--- a/header_test.go
+++ b/header_test.go
@@ -69,3 +69,36 @@ func TestParseHeaderParams_malformed(t *testing.T) {
 		t.Error("Expected an error when parsing malformed header params")
 	}
 }
+
+func TestHeaderPicker_Pick(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		predefinedHeaders := []string{"From", "to"}
+		headers := header{
+			"from: fst",
+			"To: snd",
+		}
+		picker := newHeaderPicker(headers)
+		for i, k := range predefinedHeaders {
+			if headers[i] != picker.Pick(k) {
+				t.Errorf("Parameter %s not found in headers %s", k, headers)
+			}
+		}
+	})
+	t.Run("a few same headers", func(t *testing.T) {
+		predefinedHeaders := []string{"to", "to", "to"}
+		// same headers must returns from Bottom to Top
+		headers := header{
+			"To: trd",
+			"To: snd",
+			"To: fst",
+		}
+		var lh = len(headers) - 1
+		picker := newHeaderPicker(headers)
+		for i, k := range predefinedHeaders {
+			if headers[lh-i] != picker.Pick(k) {
+				t.Errorf("Parameter %s not found in headers %s", k, headers)
+			}
+		}
+
+	})
+}


### PR DESCRIPTION
From RFC 
https://tools.ietf.org/html/rfc6376#section-3.5
tag `h=` 

>       Header field
>       names MUST be compared against actual header field names in a
>       case-insensitive manner

For cases when you predefined headers in options